### PR TITLE
Some fixes (check description)

### DIFF
--- a/OpenTibia/OpenTibia.Animation/FrameDuration.cs
+++ b/OpenTibia/OpenTibia.Animation/FrameDuration.cs
@@ -56,7 +56,6 @@ namespace OpenTibia.Animation
                 case ThingCategory.Item:
                     this.SetTo(500, 500);
                     break;
-
                 case ThingCategory.Outfit:
                     this.SetTo(300, 300);
                     break;
@@ -64,9 +63,10 @@ namespace OpenTibia.Animation
                 case ThingCategory.Effect:
                     this.SetTo(100, 100);
                     break;
+                default:
+                    this.SetTo(0, 0);
+                    break;
             }
-
-            this.SetTo(0, 0);
         }
 
         #endregion

--- a/OpenTibia/OpenTibia.Client/Things/ThingTypeSerializer.cs
+++ b/OpenTibia/OpenTibia.Client/Things/ThingTypeSerializer.cs
@@ -161,7 +161,7 @@ namespace OpenTibia.Client.Things
             if (frameGroupsEnabled && thing.Category == ThingCategory.Outfit)
             {
                 groupCount = thing.FrameGroupCount;
-                writer.Write(groupCount);
+                writer.Write((byte)groupCount); // cast to 1 byte
             }
 
             for (byte k = 0; k < groupCount; k++)
@@ -400,7 +400,7 @@ namespace OpenTibia.Client.Things
 
                         ushort nameLength = reader.ReadUInt16();
                         byte[] buffer = reader.ReadBytes(nameLength);
-                        thing.MarketName = Encoding.UTF8.GetString(buffer, 0, buffer.Length);
+                        thing.MarketName = Encoding.Default.GetString(buffer, 0, buffer.Length);
                         thing.MarketRestrictVocation = reader.ReadUInt16();
                         thing.MarketRestrictLevel = reader.ReadUInt16();
                         break;
@@ -605,7 +605,7 @@ namespace OpenTibia.Client.Things
                     writer.Write(thing.MarketTradeAs);
                     writer.Write(thing.MarketShowAs);
                     writer.Write((ushort)thing.MarketName.Length);
-                    writer.Write(Encoding.UTF8.GetBytes(thing.MarketName));
+                    writer.Write(Encoding.Default.GetBytes(thing.MarketName));
                     writer.Write(thing.MarketRestrictVocation);
                     writer.Write(thing.MarketRestrictLevel);
                 }


### PR DESCRIPTION
- Guarantee encoding writing/reading for market name (tested with some special names like 'Jalapeño Pepper')
- Fix when try convert an older version (without FrameDurations) to newer version (with FrameDurations) try to write null frame durations. (initialize before write if not exists)
- Fix on frame group count (writing 4 bytes, the correct is 1 byte)

ps: all this changes has been made for personal use and works fine after trying convert 10.41 (without frameduration/framegroup) to 10.98 (with frameduration/framegroup)